### PR TITLE
Feat: improved updating, notifying and moving Nodes API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* Feat: improved updating, notifying and moving Nodes API [#2](https://github.com/Novident/novident-nodes/pull/2)
+
 ## 1.0.2
 
 * Chore: added tests for nodes.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,28 @@ The nodes within this package have a specific behavior, and they are capable of 
 > [!NOTE]
 > This doesn't mean we have to perform certain validations, as some errors could occur.
 
+> [!TIP]
+> When you want to update the state of a Node, you can use the `notify()` or `notify(propagate: true)` method.
+>
+> * `propagate`: determines if the Node will notify its parent Node about its changes.
+>
+> For example, when using **Drag and Drop** features, you will need to update all Nodes up to the Main Node that contains your node, since moving nodes requires removing and inserting them in different positions and under different parents:
+>
+> ```dart
+> // ... perform your operations here
+> // first, notify the root that this Node has changed
+> oldParentOfNode.notify(propagate: true);
+> // then, notify the root that this Node has changed too 
+> // and contains the new node
+> newParentOfNode.notify(propagate: true);
+> ```
+>
+> However, if you only want to update a specific part that doesn't require updating multiple Nodes simultaneously, you can simply use: 
+>
+> ```dart
+> yourNode.notify();
+> ```
+
 In the case of Novident, these packages have multiple uses in different packages:
 
 - **[Novident-corkboard](https://github.com/Novident/novident-corkboard):** Nodes are used to display nodes in different ways in a customized way, such as creating index cards that can have a defined shape or a defined point on the screen, or even having what we call freeform node mode, which allows us to move these cards to any position we want.

--- a/lib/src/nodes/node.dart
+++ b/lib/src/nodes/node.dart
@@ -35,7 +35,7 @@ abstract class Node extends NodeNotifier with NodeVisitor, ClonableMixin<Node> {
   /// should trigger updates in dependent systems.
   void notify({bool propagate = true}) {
     notifyListeners();
-    if(propagate) {
+    if (propagate) {
       owner?.notify(propagate: propagate);
     }
   }

--- a/lib/src/nodes/node.dart
+++ b/lib/src/nodes/node.dart
@@ -33,8 +33,11 @@ abstract class Node extends NodeNotifier with NodeVisitor, ClonableMixin<Node> {
   ///
   /// Should be called whenever the node's state changes in a way that
   /// should trigger updates in dependent systems.
-  void notify() {
+  void notify({bool propagate = true}) {
     notifyListeners();
+    if(propagate) {
+      owner?.notify(propagate: propagate);
+    }
   }
 
   /// Returns the index of this node within its parent list.

--- a/lib/src/nodes/node_container.dart
+++ b/lib/src/nodes/node_container.dart
@@ -315,7 +315,7 @@ abstract class NodeContainer extends Node {
     if (shouldNotify) notify(propagate: propagateNotifications);
   }
 
-  /// Adds a node to the end of children list.
+  /// Move the [Node] passed to a new parent.
   ///
   /// * [node]: The [Node] that you want to move
   /// * [to]: The [NodeContainer] where the [Node] will be moved
@@ -353,7 +353,7 @@ abstract class NodeContainer extends Node {
     return true;
   }
 
-  /// Adds a node to the end of children list.
+  /// Find the [Node] by the [id] passed and Move it to a new parent.
   ///
   /// * [id]: The identifier of the [Node] that you want to move
   /// * [to]: The [NodeContainer] where the [Node] will be moved

--- a/lib/src/nodes/node_container.dart
+++ b/lib/src/nodes/node_container.dart
@@ -191,6 +191,9 @@ abstract class NodeContainer extends Node {
     return false;
   }
 
+  /// Gets the list of direct child nodes.
+  List<Node> get children => _children;
+
   /// Gets the first child node.
   /// Throws if there are no children.
   Node get first => _children.first;

--- a/lib/src/nodes/node_container.dart
+++ b/lib/src/nodes/node_container.dart
@@ -92,7 +92,8 @@ abstract class NodeContainer extends Node {
   /// [reversed]: Whether to traverse in reverse order
   /// Returns the first matching node or null if none found
   @override
-  Node? visitAllNodes({required Predicate shouldGetNode, bool reversed = false}) {
+  Node? visitAllNodes(
+      {required Predicate shouldGetNode, bool reversed = false}) {
     for (int i = reversed ? length - 1 : 0;
         reversed ? i >= 0 : i < length;
         reversed ? i-- : i++) {
@@ -100,7 +101,8 @@ abstract class NodeContainer extends Node {
       if (shouldGetNode(node)) {
         return node;
       }
-      final Node? foundedNode = node.visitAllNodes(shouldGetNode: shouldGetNode);
+      final Node? foundedNode =
+          node.visitAllNodes(shouldGetNode: shouldGetNode);
       if (foundedNode != null) return foundedNode;
     }
     return null;
@@ -543,7 +545,8 @@ abstract class NodeContainer extends Node {
     bool propagateNotifications = false,
     bool insertIfNotExist = true,
   }) {
-    final int index = _children.indexWhere((Node node) => node.id == newNodeState.id);
+    final int index =
+        _children.indexWhere((Node node) => node.id == newNodeState.id);
     if (index < 0 && !insertIfNotExist) {
       return;
     } else if (index < 0 && insertIfNotExist) {
@@ -588,7 +591,8 @@ abstract class NodeContainer extends Node {
   }
 
   /// Updates the child node at the specified index.
-  void updateAt(int index, Node newNodeState, {bool propagateNotifications = false}) {
+  void updateAt(int index, Node newNodeState,
+      {bool propagateNotifications = false}) {
     if (index < 0) return;
     onChange(
       NodeUpdate(

--- a/test/novident_nodes_test.dart
+++ b/test/novident_nodes_test.dart
@@ -95,6 +95,30 @@ void main() {
     expect(node.first.castToDir.first.castToFile.id, 'test 3');
   });
 
+  test('should notify until its parent', () {
+    final DirectoryNode node = DirectoryNode(
+      details: NodeDetails.zero(),
+      children: <Node>[
+        FileNode(
+          details: NodeDetails.byId(id: 'test', level: 1),
+          content: '',
+          name: 'File 1',
+        ),
+      ],
+      name: 'Dir',
+    );
+    expect(node.first.owner, node);
+    final StringBuffer buffer = StringBuffer();
+    node.addListener(() {
+      buffer.write('Directory');
+    });
+    node.first.addListener(() {
+      buffer.writeln('${' ' * (node.first.level + 1)}File 1');
+    });
+    node.first.notify(propagate: true);
+    expect(buffer.toString().split('\n').reversed.join('\n'), 'Directory\n  File 1');
+  });
+
   test('should return a correct json', () {
     // The level will be updated automatically during Node build
     final DirectoryNode node = DirectoryNode(

--- a/test/novident_nodes_test.dart
+++ b/test/novident_nodes_test.dart
@@ -116,7 +116,8 @@ void main() {
       buffer.writeln('${' ' * (node.first.level + 1)}File 1');
     });
     node.first.notify(propagate: true);
-    expect(buffer.toString().split('\n').reversed.join('\n'), 'Directory\n  File 1');
+    expect(buffer.toString().split('\n').reversed.join('\n'),
+        'Directory\n  File 1');
   });
 
   test('should return a correct json', () {


### PR DESCRIPTION
## Description

Several aspects of `Node` notifications and updates have been improved.

In any case, new functions have been added to update a `Node` (only in classes that derive from `NodeContainer`), such as:

* `update`: Update a child `Node` if it is founded, or insert if it does not exist.
* `updateWhere`: Updates the child node by a predicate.
* `updateAt`: Updates the child node at the specified index.

A new parameter has also been added to the notify function:

This new method allows us to decide whether we want the change notification to be sent only to this `Node` or if we want all parents to also be updated with the new information.

```dart
void notify({bool propagate = true});
```

And finally, default functions were added to move nodes from one location to another:

* `moveNode`: Moves the node to the target passed to it, and performs the necessary operations for the move to be effective, in addition to automatically notifying changes.
* `moveNodeById`: Moves the node (if found, since it depends on the `id` passed to it) to the target passed to it (almost the same as `moveNode` but using an `id` as a base instead of the `Node` object).

## Type of Change

- [x] ✨ **Feature:** New functionality without breaking existing features.
- [ ] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [ ] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [x] 🧪 **Tests:** New or modified tests
- [x] 📝 **Documentation:** Updates or additions to documentation.
- [x] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.